### PR TITLE
Login refactor

### DIFF
--- a/packages/native-frontend/.eslintrc.js
+++ b/packages/native-frontend/.eslintrc.js
@@ -2,4 +2,9 @@
 module.exports = {
     extends: "expo",
     ignorePatterns: ["/app-example/**/"],
+    "import/resolver": {
+        "typescript": {
+            "project": "./tsconfig.json"
+        }
+    },
 };

--- a/packages/native-frontend/app/login.tsx
+++ b/packages/native-frontend/app/login.tsx
@@ -1,32 +1,20 @@
 import { Text, View, KeyboardAvoidingView, Platform, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { SafeAreaView } from "react-native-safe-area-context";
 import LoginPrompt from "@/components/login/loginPrompt";
-import { fetchLogin } from "@/fetchers/authFetchers";
+// import { fetchLogin } from "@/fetchers/authFetchers";
 import { useState } from "react";
 import { Redirect } from "expo-router";
+import { login } from '@/util/loginHelper';
 
 export default function Login() {
-    const [loginFailed, setLoginFailed] = useState(false);
-    const [loggedIn, setLoggedIn] = useState(false);
+    // const [loginFailed, setLoginFailed] = useState(false);
+    const [loggedIn, setLoggedIn] = useState<boolean>();
     function handleLogin(email: string, password: string): void {
-        fetchLogin(email, password)
-            .then((res: Response) => {
-                if (res.ok) {
-                    console.log(`Authorized.`);
-                    return res.text();
-                } else {
-                    setLoginFailed(true);
-                    throw new Error("Login failed.")
-                }
+        login(email, password)
+            .then((result: boolean) => {
+                setLoggedIn(result);
             })
-            .then((res_data) => {
-                // NOTE: login token is being retrieved, but not being stored anywhere yet for protected routing
-                console.log((`auth token: ${res_data}`));
-                setLoggedIn(true);
-            })
-            .catch((error: Error) => {
-                console.log(`fetchLogin err: ${error.message}`);
-            })
+            
     }
     if (loggedIn) {
         return (<Redirect href="/(tabs)" />)
@@ -45,7 +33,7 @@ export default function Login() {
                     className="flex-1"
                 >
                     <View className="flex-1 justify-center items-center">
-                        <LoginPrompt handleSubmit={handleLogin} loginFailed={loginFailed} />
+                        <LoginPrompt handleSubmit={handleLogin} loggedIn={loggedIn} />
                     </View>
                 </KeyboardAvoidingView>
             </TouchableWithoutFeedback>

--- a/packages/native-frontend/components/login/loginPrompt.tsx
+++ b/packages/native-frontend/components/login/loginPrompt.tsx
@@ -3,10 +3,10 @@ import { useState } from 'react';
 
 type Props = {
 	handleSubmit: (email: string, password: string) => void;
-	loginFailed: boolean;
+	loggedIn: boolean | undefined;
 }
 
-export default function LoginPrompt({ handleSubmit, loginFailed }: Props) {
+export default function LoginPrompt({ handleSubmit, loggedIn }: Props) {
 	const [email, setEmail] = useState<string>("");
 	const [password, setPassword] = useState<string>("");
 
@@ -39,7 +39,9 @@ export default function LoginPrompt({ handleSubmit, loginFailed }: Props) {
 				<Text className="text-white text-base font-semibold">Login</Text>
 			</Pressable>
 
-			{loginFailed && (
+
+			{//loggedIn = undefined when first on the page and false when login fails.
+			(loggedIn != undefined && !loggedIn) && (
 				<Text className="text-red-500 text-sm text-center mb-4">
 					Invalid email or password.
 				</Text>

--- a/packages/native-frontend/tsconfig.json
+++ b/packages/native-frontend/tsconfig.json
@@ -7,11 +7,6 @@
             "@/*": ["./*"]
         }
     },
-    "import/resolver": {
-        "typescript": {
-            "project": "./tsconfig.json"
-        }
-    },
     "include": [
         "**/*.ts",
         "**/*.tsx",

--- a/packages/native-frontend/util/loginHelper.ts
+++ b/packages/native-frontend/util/loginHelper.ts
@@ -1,0 +1,32 @@
+import { fetchLogin } from "@/fetchers/authFetchers";
+
+/**
+ * returns a promise that is either true for logged in or false for not logged in.
+ * When logged in authorization token needs to be saved
+ */
+function login(email: string, password: string): Promise<boolean>
+{
+    return fetchLogin(email, password)
+        .then((res: Response) => {
+            if (res.ok) { // 200s status
+                console.log(`Authorized.`);
+                return res.text() // get the authorization token.
+                    .then((res_data) => {
+                        // NOTE: login token is being retrieved, but not being stored anywhere yet for protected routing
+                        console.log((`auth token: ${res_data}`));
+                        return true; // sucessful loggin.
+                    });
+            } else { // non 200s status.
+                console.log(`Unauthorized`)
+                return false; // failed loggin.
+            }
+        })
+        .catch((error: Error) => {
+            console.log(`fetchLogin err: ${error.message}`);
+            return false // failed login even more so.
+        })
+}
+
+export {
+    login,
+}


### PR DESCRIPTION
1. Refactored a login function from the login page to a file in the util folder. This way, the signup page can use the function to log in the user as well. 
2. I also made a small change to the signup page to remove the failedLogin hook. Thus, it uses the return from the login function.